### PR TITLE
Relative links fix

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,8 +33,11 @@ Configuration options:
 		<head>
 			<title>titleToken</title>
 			<meta charset="utf-8" />
+			<link rel="stylesheet" href="##SITE_BASE##/css/default.css">
 		</head>
 		
+	Note: **##SITE_BASE##** will be translated to a relative path from the markdown file's directory to base directory. This is not necessary if *recursiveInput* configuration is false.
+
 * footerHtmlFile : Location of header HTML file as String, ${project.basedir}/src/main/resources/markdown/html/footer.html
 	
 	Example:


### PR DESCRIPTION
Relative links to css, js, and image files in the header and footer does not work for markdown files in sub-folders. This patch fixes it.
