### PR TITLE
Fix for title null pointer

### DIFF
--- a/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
+++ b/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
@@ -161,7 +161,7 @@ public class MdPageGeneratorMojo extends AbstractMojo {
 				getLog().info("There is no input folder for the project. Skipping.");
 				return false;
 			}
-			int baseDepth = StringUtils.countMatches(inputFile.getAbsolutePath(), "/");
+			int baseDepth = StringUtils.countMatches(inputFile.getAbsolutePath(), File.separator);
 			 
 			// Reading just the markdown dir and sub dirs if recursive option set
 			List<File> markdownFiles = getFilesAsArray(FileUtils.iterateFiles(new File(inputDirectory), new String[] { "md" }, recursiveInput));
@@ -174,7 +174,7 @@ public class MdPageGeneratorMojo extends AbstractMojo {
 				MarkdownDTO dto = new MarkdownDTO();
 				dto.markdownFile = file;
 
-				dto.folderDepth = StringUtils.countMatches(file.getAbsolutePath(), "/") - (baseDepth + 1);
+				dto.folderDepth = StringUtils.countMatches(file.getAbsolutePath(), File.separator) - (baseDepth + 1);
                                 
                                 if(alwaysUseDefaultTitle){
                                     dto.title = defaultTitle;


### PR DESCRIPTION
This request contains the following changes

- Addition of a new plugin property alwaysUseDefaultTitle, used to force the plugin not to search for a title only use the default one. 
- Altered the title generation logic a bit. If alwaysUseDefaultTitle is not set will search for a title as before. If no title can be found will set it to default. 
- Added a null check on the find and replace of the title in the HTML. This is because the title can be null at this point, a null title sets the title to "'. 
- Added support for Setext style titles. Looks for titles with - or = bellow them as well as the original # version. First one it finds will be the title. 

Done basic testing on this. It fixes the original issue I had that spawned this change.