### PR TITLE
Few additional features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
 			<groupId>org.pegdown</groupId>
 			<artifactId>pegdown</artifactId>
-			<version>1.4.1</version>
+			<version>1.5.0</version>
 		</dependency>
 
         <!-- Maven plugin testing -->

--- a/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MDToHTMLExpLinkRender.java
+++ b/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MDToHTMLExpLinkRender.java
@@ -11,11 +11,14 @@ public class MDToHTMLExpLinkRender extends LinkRenderer {
     @Override
     public Rendering render(ExpLinkNode node, String text) {
         String url = node.url;
-        if (!url.startsWith("http://") && !url.startsWith("https://") && url.endsWith(".md")) {
-            url = url.substring(0, url.length() - 2) + "html";
+        if (!url.startsWith("http://") && !url.startsWith("https://")) {
+            if(url.endsWith(".md")){
+                url = url.substring(0, url.length() - 2) + "html";
+            }else if(url.contains(".md#")){
+                url = url.replace(".md#", ".html#");
+            }
         }
         Rendering rendering = new Rendering(url, text);
         return StringUtils.isEmpty(node.title) ? rendering : rendering.withAttribute("title", encode(node.title));
     }
-
 }

--- a/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
+++ b/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
@@ -74,7 +74,7 @@ public class MdPageGeneratorMojo extends AbstractMojo {
 	private enum EPegdownExtensions {
 		NONE(0x00), SMARTS(0x01), QUOTES(0x02), SMARTYPANTS(EPegdownExtensions.SMARTS.getValue() + EPegdownExtensions.QUOTES.getValue()), ABBREVIATIONS(
 				0x04), HARDWRAPS(0x08), AUTOLINKS(0x10), TABLES(0x20), DEFINITIONS(0x40), FENCED_CODE_BLOCKS(0x80), WIKILINKS(0x100), ALL(
-				0x0000FFFF), SUPPRESS_HTML_BLOCKS(0x00010000), SUPPRESS_INLINE_HTML(0x00020000), SUPPRESS_ALL_HTML(0x00030000);
+				0x0000FFFF), SUPPRESS_HTML_BLOCKS(0x00010000), SUPPRESS_INLINE_HTML(0x00020000), SUPPRESS_ALL_HTML(0x00030000), ANCHORLINKS(0x400);
 
 		private final int value;
 
@@ -185,8 +185,8 @@ public class MdPageGeneratorMojo extends AbstractMojo {
 
                 File htmlFile = new File(
                         recursiveInput
-                                ? outputDirectory + "/" + file.getParentFile().getPath().substring(inputFile.getPath().length()) + "/" + file.getName().replaceAll(".md", ".html")
-                                : outputDirectory + "/" + file.getName().replaceAll(".md", ".html")
+                                ? outputDirectory + File.separator + file.getParentFile().getPath().substring(inputFile.getPath().length()) + File.separator + file.getName().replaceAll(".md", ".html")
+                                : outputDirectory + File.separator + file.getName().replaceAll(".md", ".html")
                 );
 				dto.htmlFile = htmlFile;
 


### PR DESCRIPTION
I added a few things for my own use that you may like to add. 

- (Minor) replaced another few "/" with file.separator
- Updated the pegdown version to 1.5.0
- Added an extra pegdownextension to the list: ANCHORLINKS. This is new to pegdown 1.5.0 and allows pegdown to turn things like headers into anchors.
- The custom MD to HTML render to change relative links from .md to .html worked great but would fail if your local links had anchors in them. Ex: something.md#Anchor . Added an extra section to replace the first occurance of ".md#" with ".html#" . This search should cover the bulk of the cases but can still fail under weird circumstances. May want to come up with a more robust solution if it becomes a problem


