### PR TITLE
Allow configuration of parsing timeout

### DIFF
--- a/src/test/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojoTest.java
+++ b/src/test/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojoTest.java
@@ -1,7 +1,9 @@
 package com.ruleoftech.markdown.page.generator.plugin;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.pegdown.ParsingTimeoutException;
 
 import java.io.File;
 
@@ -83,6 +85,22 @@ public class MdPageGeneratorMojoTest
 
         File page11 = new File(getBasedir(), "/target/test-harness/recursive-project/html/pages/embedded/page-1-1.html");
         assertTrue(page11.exists());
+    }
+
+    public void testParsingTimeout()
+            throws Exception {
+        File pom = getTestFile("src/test/resources/timeout-project/pom.xml");
+        assertTrue(pom.exists());
+
+        MdPageGeneratorMojo mdPageGeneratorMojo = (MdPageGeneratorMojo) lookupMojo("generate", pom);
+        assertNotNull(mdPageGeneratorMojo);
+
+        try {
+            mdPageGeneratorMojo.execute();
+            fail();
+        } catch (Exception ex) {
+            assertEquals(ParsingTimeoutException.class, ex.getCause().getClass());
+        }
     }
 
 }

--- a/src/test/resources/timeout-project/pom.xml
+++ b/src/test/resources/timeout-project/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.ruleoftech.test</groupId>
+    <artifactId>basic</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Basic</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.ruleoftech</groupId>
+                <artifactId>markdown-page-generator-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <inputDirectory>${basedir}/src/test/resources/basic-project/src/main/resources/markdown</inputDirectory>
+                    <outputDirectory>${basedir}/target/test-harness/basic-project/html</outputDirectory>
+                    <pegdownExtensions>TABLES</pegdownExtensions>
+                    <parsingTimeoutInMillis>0</parsingTimeoutInMillis>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/timeout-project/src/main/resources/markdown/README.md
+++ b/src/test/resources/timeout-project/src/main/resources/markdown/README.md
@@ -1,0 +1,9 @@
+# Lorem ipsum
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.
+Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.
+Proin porttitor, orci nec nonummy molestie, enim est eleifend mi, non fermentum diam nisl sit amet erat.
+Duis semper. Duis arcu massa, scelerisque vitae, consequat in, pretium a, enim. Pellentesque congue. Ut in risus volutpat libero pharetra tempor.
+Cras vestibulum bibendum augue. Praesent egestas leo in pede. Praesent blandit odio eu enim. Pellentesque sed dui ut augue blandit sodales.
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aliquam nibh.
+Mauris ac mauris sed pede pellentesque fermentum. Maecenas adipiscing ante non diam sodales hendrerit.


### PR DESCRIPTION
This will fix #14 (Allow configuration of parsing timeout).

It introduces the new configuration parameter `parsingTimeoutInMillis`, which is simply passed into the pegdown parser. The default is pegdown's default, `2000`.

A unit test is provided.