### PR TITLE
Markdown generation does not fail if header/footer file is missing

### DIFF
--- a/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
+++ b/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
@@ -63,7 +63,7 @@ public class MdPageGeneratorMojo extends AbstractMojo {
 	private Long parsingTimeoutInMillis;
 
         @Parameter(property = "generate.inputFileExtension", defaultValue="md")
-	private final String inputFileExtension = "md";
+	private String inputFileExtension = "md";
 
 	// Possible options
 	// SMARTS: Beautifies apostrophes, ellipses ("..." and ". . .") and dashes ("--" and "---")


### PR DESCRIPTION
When the header or footer HTML file can not be found the build will not automatically fail. I added a parameter ```failIfFilesAreMissing``` if the build should actually still fail when the files are missing.

This could of course be changed into something like ```ignoreMissingFiles``` so it still fails by default, if desired.