### PR TITLE
Add variable suport

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,6 +24,31 @@ Default configuration which can be overridden:
 
 Configuration options:
 
+* variables substitution
+    
+    Example:
+
+	    header.html
+	    
+            <!DOCTYPE html>
+            <html lang="${lang}">
+            <head>
+            </head>
+
+	    page.md:
+	    
+            # Title
+            {lang=en}
+
+
+       will output in page.html:
+
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+            </head>
+            <h1>Title</h1>
+           
 * headerHtmlFile : Location of header HTML file as String, ${project.basedir}/src/main/resources/markdown/html/header.html
 	
 	Example:

--- a/src/test/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojoTest.java
+++ b/src/test/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojoTest.java
@@ -1,7 +1,6 @@
 package com.ruleoftech.markdown.page.generator.plugin;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.pegdown.ParsingTimeoutException;
 
@@ -121,5 +120,31 @@ public class MdPageGeneratorMojoTest
             assertEquals(ParsingTimeoutException.class, ex.getCause().getClass());
         }
     }
+
+    public void testSubstituteProject()
+            throws Exception {
+        File pom = getTestFile("src/test/resources/substitute-project/pom.xml");
+        assertTrue(pom.exists());
+
+        MdPageGeneratorMojo mdPageGeneratorMojo = (MdPageGeneratorMojo) lookupMojo("generate", pom);
+        assertNotNull(mdPageGeneratorMojo);
+
+        mdPageGeneratorMojo.execute();
+
+        File generatedMarkdown = new File(getBasedir(), "/target/test-harness/substitute-project/html/README.html");
+        assertTrue(generatedMarkdown.exists());
+
+        String html = FileUtils.readFileToString(new File(getBasedir() + "/target/test-harness/substitute-project/html/README.html"));
+        
+        assertFalse("Shouldn't contains the var declaration", html.contains("headerSubstitution"));
+        assertFalse("Shouldn't contains the var declaration", html.contains("footerSubstitution"));
+        
+        assertFalse("Shouldn't contains the original var", html.contains("${headerSubstitution}"));
+        assertFalse("Shouldn't contains the original var", html.contains("${footerSubstitution}"));
+        
+        assertTrue("Should contains the replaced var", html.contains("The new header"));
+        assertTrue("Should contains the replaced var", html.contains("The new footer"));
+    }
+
 
 }

--- a/src/test/resources/substitute-project/pom.xml
+++ b/src/test/resources/substitute-project/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.ruleoftech.test</groupId>
+    <artifactId>basic</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Basic</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.ruleoftech</groupId>
+                <artifactId>markdown-page-generator-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <inputDirectory>${basedir}/src/test/resources/substitute-project/src/main/resources/markdown</inputDirectory>
+                    <outputDirectory>${basedir}/target/test-harness/substitute-project/html</outputDirectory>
+                    <headerHtmlFile>${basedir}/src/test/resources/substitute-project/src/main/resources/markdown/html/header.html</headerHtmlFile>
+                    <footerHtmlFile>${basedir}/src/test/resources/substitute-project/src/main/resources/markdown/html/footer.html</footerHtmlFile>
+                    <pegdownExtensions>TABLES</pegdownExtensions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/substitute-project/src/main/resources/markdown/README.md
+++ b/src/test/resources/substitute-project/src/main/resources/markdown/README.md
@@ -1,0 +1,9 @@
+# Lorem ipsum
+
+{headerSubstitution=The new header}
+
+Some blah blah...
+
+{footerSubstitution=The new footer}
+
+Some blah blah blah...

--- a/src/test/resources/substitute-project/src/main/resources/markdown/html/footer.html
+++ b/src/test/resources/substitute-project/src/main/resources/markdown/html/footer.html
@@ -1,0 +1,3 @@
+        <p>${footerSubstitution}</p>
+    </body>
+</html>

--- a/src/test/resources/substitute-project/src/main/resources/markdown/html/header.html
+++ b/src/test/resources/substitute-project/src/main/resources/markdown/html/header.html
@@ -1,0 +1,6 @@
+<html>
+    <head>
+        <title></title>
+        <meta name="description" content="${headerSubstitution}" />
+    </head>
+    <body>


### PR DESCRIPTION
Hi,

This commit allow you to declare variables in the markdown file and use it in the header an footer.

for example:
in file.md: _{var:value}_ will _replace_  in _header.html_ ${var} with _value_.