### PR TITLE
Fix: Problems inside maven multimodule or aggregator project

### DIFF
--- a/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
+++ b/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
@@ -205,7 +205,10 @@ public class MdPageGeneratorMojo extends AbstractMojo {
         }
 
         getLog().info("Pre-processing markdown files from input directory: " + inputDirectory);
-        preprocessMarkdownFiles(new File(inputDirectory));
+        if (!preprocessMarkdownFiles(new File(inputDirectory))){
+			getLog().info("Pre-processing markdown files from input directory: markdown files not found" + inputDirectory);
+			return;
+		}
 
         if (!markdownDTOs.isEmpty()) {
             getLog().info("Process Pegdown extension options");


### PR DESCRIPTION
pom.xml     (parent) -> Declaration this maven plugin
  -- pom.xml  (Child A needs this plugin)
  -- pom.xml  (Child B needs not this plugin)  <-- Error
  -- pom.xml  (Child C needs this plugin)