### PR TITLE
Enabling flexmark boolean options

### DIFF
--- a/src/test/resources/substitute-project/pom.xml
+++ b/src/test/resources/substitute-project/pom.xml
@@ -40,6 +40,7 @@
                     <footerHtmlFile>${basedir}/src/main/resources/markdown/html/footer.html</footerHtmlFile>
                     <applyFiltering>true</applyFiltering>
                     <pegdownExtensions>TABLES</pegdownExtensions>
+                    <flexmarkParserOptions>LISTS_ORDERED_LIST_MANUAL_START</flexmarkParserOptions>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This is really difficult to design, but I needed flexmark options available here: https://github.com/vsch/flexmark-java/blob/master/flexmark/src/main/java/com/vladsch/flexmark/parser/Parser.java

These changes allow you to specify those options with a <flexmarkParserOptions> configuration element, but it assumes the type is boolean and assumes to set it to the default value as specified in that class.

I know it works with option `LISTS_ORDERED_LIST_MANUAL_START`.  That option is required to make flexmark behave more like gitlab/github for lists.

Not sure how this should best be implemented for more generic cases.  95% of the fields are boolean though.