### PR TITLE
Add test for fenced code block rendering

### DIFF
--- a/src/test/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojoTest.java
+++ b/src/test/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojoTest.java
@@ -430,6 +430,31 @@ public class MdPageGeneratorMojoTest extends BetterAbstractMojoTestCase {
 
     }
 
+    public void testCodeBlockProject() throws Exception {
+        final String expectedGeneratedHTMLFile = "/target/test-harness/codeblock-project/target/html/README.html";
+
+        File pom = getTestFile("src/test/resources/codeblock-project/pom.xml");
+        assertTrue(pom.exists());
+
+        MdPageGeneratorMojo mdPageGeneratorMojo = (MdPageGeneratorMojo) lookupConfiguredMojo(pom, "generate");
+        assertNotNull(mdPageGeneratorMojo);
+
+        mdPageGeneratorMojo.execute();
+
+        File generatedMarkdown = new File(getBasedir(), expectedGeneratedHTMLFile);
+        assertTrue("Expected HTML file does not exist: " + generatedMarkdown, generatedMarkdown.exists());
+
+      String html = FileUtils.readFileToString(generatedMarkdown, Charset.defaultCharset());
+
+        assertEquals("<h1>Lorem ipsum</h1>\n"
+                + "<pre><code>&lt;dependency&gt;\n"
+                + "    &lt;groupId&gt;groupid&lt;/groupId&gt;\n"
+                + "    &lt;artifactId&gt;artifactid&lt;/artifactId&gt;\n"
+                + "    &lt;version&gt;version&lt;/version&gt;\n"
+                + "&lt;/dependency&gt;\n"
+                + "</code></pre>\n", html);
+    }
+
     private void createSubFoldersAndFiles(String[] folderNames, String[] fileNames, File sourceFolder) throws IOException {
         for (String folderName : folderNames) {
             final File subFolder = getSubFolder(sourceFolder, folderName);

--- a/src/test/resources/codeblock-project/pom.xml
+++ b/src/test/resources/codeblock-project/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.ruleoftech.test</groupId>
+    <artifactId>codeblock-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Basic</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+
+        <!-- Added to keep everything out of the source tree -->
+        <directory>${project.basedir}/../../../../target/test-harness/codeblock-project/target</directory>
+
+        <plugins>
+            <plugin>
+                <groupId>com.ruleoftech</groupId>
+                <artifactId>markdown-page-generator-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <pegdownExtensions>FENCED_CODE_BLOCKS</pegdownExtensions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/codeblock-project/src/main/resources/markdown/README.md
+++ b/src/test/resources/codeblock-project/src/main/resources/markdown/README.md
@@ -1,0 +1,9 @@
+# Lorem ipsum
+
+```
+<dependency>
+    <groupId>groupid</groupId>
+    <artifactId>artifactid</artifactId>
+    <version>version</version>
+</dependency>
+```


### PR DESCRIPTION
Relates to #43 where without explicitly specifying FENCED_CODE_BLOCKS pegdown extensions configuration the HTML isn't rendered as it should.