### PR TITLE
Fix replacing input file extension with output file extension

### DIFF
--- a/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
+++ b/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
@@ -386,10 +386,10 @@ public class MdPageGeneratorMojo extends AbstractMojo {
                                 ? outputDirectory + File.separator
                                         + file.getParentFile().getPath().substring(inputDirectory.getPath().length())
                                         + File.separator + file.getName().replaceAll(
-                                                "." + inputFileExtension,
-                                                "." + outputFileExtension)
-                                : outputDirectory + File.separator + file.getName().replaceAll("." + inputFileExtension,
-                                        "." + outputFileExtension));
+                                                "\\." + inputFileExtension,
+                                                "\\." + outputFileExtension)
+                                : outputDirectory + File.separator + file.getName().replaceAll("\\." + inputFileExtension,
+                                        "\\." + outputFileExtension));
 
                 getLog().debug("File htmlFile() " + dto.htmlFile);
 

--- a/src/test/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojoTest.java
+++ b/src/test/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojoTest.java
@@ -430,6 +430,21 @@ public class MdPageGeneratorMojoTest extends BetterAbstractMojoTestCase {
 
     }
 
+    public void testFilenameProject() throws Exception {
+        final String expectedGeneratedHTMLFile = "/target/test-harness/filename-project/target/html/stammdaten.html";
+
+        File pom = getTestFile("src/test/resources/filename-project/pom.xml");
+        assertTrue(pom.exists());
+
+        MdPageGeneratorMojo mdPageGeneratorMojo = (MdPageGeneratorMojo) lookupConfiguredMojo(pom, "generate");
+        assertNotNull(mdPageGeneratorMojo);
+
+        mdPageGeneratorMojo.execute();
+
+        File generatedMarkdown = new File(getBasedir(), expectedGeneratedHTMLFile);
+        assertTrue("Expected HTML file does not exist: " + generatedMarkdown, generatedMarkdown.exists());
+    }
+
     private void createSubFoldersAndFiles(String[] folderNames, String[] fileNames, File sourceFolder) throws IOException {
         for (String folderName : folderNames) {
             final File subFolder = getSubFolder(sourceFolder, folderName);

--- a/src/test/resources/filename-project/pom.xml
+++ b/src/test/resources/filename-project/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.ruleoftech.test</groupId>
+    <artifactId>filename</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Basic</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+
+        <!-- Added to keep everything out of the source tree -->
+        <directory>${project.basedir}/../../../../target/test-harness/filename-project/target</directory>
+
+        <plugins>
+            <plugin>
+                <groupId>com.ruleoftech</groupId>
+                <artifactId>markdown-page-generator-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <pegdownExtensions>TABLES</pegdownExtensions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/filename-project/src/main/resources/markdown/stammdaten.md
+++ b/src/test/resources/filename-project/src/main/resources/markdown/stammdaten.md
@@ -1,0 +1,9 @@
+# Lorem ipsum
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.
+Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.
+Proin porttitor, orci nec nonummy molestie, enim est eleifend mi, non fermentum diam nisl sit amet erat.
+Duis semper. Duis arcu massa, scelerisque vitae, consequat in, pretium a, enim. Pellentesque congue. Ut in risus volutpat libero pharetra tempor.
+Cras vestibulum bibendum augue. Praesent egestas leo in pede. Praesent blandit odio eu enim. Pellentesque sed dui ut augue blandit sodales.
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aliquam nibh.
+Mauris ac mauris sed pede pellentesque fermentum. Maecenas adipiscing ante non diam sodales hendrerit.


### PR DESCRIPTION
ReplaceAll() treats the first parameter as a regular expression and without escaping the dot it will match any character.

Fixes #44 