### PR TITLE
Bumps junit from 4.11 to 4.13.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
         </dependency>
 
         <!-- Maven plugin testing -->

--- a/src/test/resources/basic-project-custom-inout-directories/pom.xml
+++ b/src/test/resources/basic-project-custom-inout-directories/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/basic-project-extension/pom.xml
+++ b/src/test/resources/basic-project-extension/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/basic-project-flexmark-option/pom.xml
+++ b/src/test/resources/basic-project-flexmark-option/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/basic-project-output-extension/pom.xml
+++ b/src/test/resources/basic-project-output-extension/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/basic-project/pom.xml
+++ b/src/test/resources/basic-project/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/codeblock-project/pom.xml
+++ b/src/test/resources/codeblock-project/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/custom-attributes/pom.xml
+++ b/src/test/resources/custom-attributes/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/empty-basic-project/pom.xml
+++ b/src/test/resources/empty-basic-project/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/encoding-project/pom.xml
+++ b/src/test/resources/encoding-project/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/example-project/pom.xml
+++ b/src/test/resources/example-project/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/filename-project/pom.xml
+++ b/src/test/resources/filename-project/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/recursive-project/pom.xml
+++ b/src/test/resources/recursive-project/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/substitute-project/pom.xml
+++ b/src/test/resources/substitute-project/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
See https://github.com/junit-team/junit4/security/advisories/GHSA-269g-pwp5-87pp

Vulnerable versions: < 4.13.1
Patched version: 4.13.1 