### PR TITLE
Clarification on variable substitution

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ Default configuration which can be overridden:
 
 Configuration options:
 
-* variables substitution
+* `applyFiltering`: apply variables substitution if `true`. Default `false`.
 
   Example:
 
@@ -47,7 +47,8 @@ Configuration options:
   `page.md`:
 
   ```markdown
-  # Title {lang=en}
+  # Title 
+  {lang=en}
   ```
 
   will output in `page.html`:


### PR DESCRIPTION
Hi,

Thanks for the plugin.

I feel like the current how-to on variables substitution in the README is imprecise.

Two informations are missing:
- variable substitution requires applyFiltering=true
- variable substitution requires the variable definition to be on its own line (cf com.ruleoftech.markdown.page.generator.plugin#isVariableLine(String))