### PR TITLE
Flexmark's renderer options support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,8 +171,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>7</source>
-                    <target>7</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
1. Added Flexmark's renderer (https://github.com/vsch/flexmark-java/wiki/Extensions#renderer) options support;
2. In maven compiler plugin configuration updated source and target versions from 7 to 8.

Fixes walokra/markdown-page-generator-plugin#57