### PR TITLE
Mark MdPagegeneratorMojo as threadSafe

### DIFF
--- a/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
+++ b/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
@@ -57,7 +57,7 @@ import com.vladsch.flexmark.util.html.Attributes;
 /**
  * Creates a static html from markdown files.
  */
-@Mojo(name = "generate")
+@Mojo(name = "generate", threadSafe = true)
 public class MdPageGeneratorMojo extends AbstractMojo {
 
     @Parameter(property = "generate.defaultTitle")


### PR DESCRIPTION
The codebase did not appear to make use of any non-final static fields so I believe this plugin can be made threadsafe.

After this change I tested:
- A multi-module project build, using `-T2C` settings, to verify warning was resolved
- Confirmed generated `plugin.xml` configured as both `instantiationStrategy` per-lookup, and `threadSafe` true

This pull request resolves https://github.com/walokra/markdown-page-generator-plugin/issues/61
