### PR TITLE
Reduce logging of List final flexmark options to debug level

### DIFF
--- a/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
+++ b/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
@@ -455,11 +455,13 @@ public class MdPageGeneratorMojo extends AbstractMojo {
 
         finalFlexmarkOptions.set(Parser.EXTENSIONS, extensions);
 
-        getLog().info("final flexmark options: ");
+        StringBuilder finalOptions = new StringBuilder("final flexmark options: ");
         for (DataKey<?> opt : finalFlexmarkOptions.keySet()) {
-            getLog().info("  " + opt.getName());
+            finalOptions.append(opt.getName());
+            finalOptions.append(" ");
         }
-
+        getLog().debug(finalOptions.toString());
+        
         Parser parser = Parser.builder(finalFlexmarkOptions).build();
         HtmlRenderer renderer = HtmlRenderer.builder(finalFlexmarkOptions).build();
 


### PR DESCRIPTION
This resolves https://github.com/walokra/markdown-page-generator-plugin/issues/60 ensuring normal execution of processMarkdown does not produce any INFO output.

Produces a single debug level message for for `final flexmark option` information