### PR TITLE
Update flexmark-java to 0.64.8 and other dependencies

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ Plugin Information:
 <plugin>
     <groupId>com.ruleoftech</groupId>
     <artifactId>markdown-page-generator-plugin</artifactId>
-    <version>2.4.3</version>
+    <version>2.5.0</version>
 </plugin>
 ```
 
@@ -139,117 +139,72 @@ Configuration options:
   Core Nodes:
 
   * AutoLink
-
   * BlockQuote
-
   * BulletList
-
   * BulletListItem
-
   * Code
-
   * Emphasis
-
   * FencedCodeBlock
-
   * Heading
-
   * Image
-
   * ImageRef
-
   * IndentedCodeBlock
-
   * Link
-
   * LinkRef
-
   * MailLink
-
   * OrderedList
-
   * OrderedList
-
   * OrderedListItem
-
   * Strikethrough
-
   * StrongEmphasis
-
   * TableBlock
-
   * TableBody
-
   * TableCaption
-
   * TableCell
-
   * TableHead
-
   * TableRow
-
   * ThematicBreak
 
 * `pegdownExtensions`: Comma separated list of constants as specified in
-  `com.vladsch.flexmark.profiles.pegdown.Extensions`. The default is `TABLES`.
+  `com.vladsch.flexmark.profile.pegdown.Extensions`. The default is `TABLES`.
 
   :information_source: [flexmark-java] has many more extensions and configuration options than
   [pegdown] in addition to extensions available in pegdown 1.6.0, the following extensions are
   available:
 
   * `SMARTS`: Beautifies `...` `. . .`, `--` and `---` to `…`, `…`, `–` and `—` respectively.
-
   * `QUOTES`: Beautifies single quotes `'`, `"`, `<<` and `>>` to `‘` `’` `‛`, `“` `”` `‟`, `«`
     and `»`
-
   * `SMARTYPANTS`: Convenience extension enabling both, `SMARTS` and `QUOTES`, at once.
-
   * `ABBREVIATIONS`: Abbreviations in the way of [PHP Markdown Extra].
-
   * `ANCHORLINKS`: Generate anchor links for headers by taking the first range of alphanumerics
     and spaces.
-
   * `HARDWRAPS`: Alternative handling of newlines, see [Github-flavoured-Markdown]
-
   * `AUTOLINKS`: Plain, undelimited autolinks the way [Github-flavoured-Markdown] implements
     them.
-
   * `TABLES`: Tables similar to [MultiMarkdown] (which is in turn like the
     [PHP Markdown Extra: tables] tables, but with colspan support).
-
   * `DEFINITIONS`: Definition lists in the way of [PHP Markdown Extra: definition list].
-
   * `FENCED_CODE_BLOCKS`: Fenced Code Blocks in the way of [PHP Markdown Extra: fenced code] or
     [Github-flavoured-Markdown].
-
   * `SUPPRESS_HTML_BLOCKS`: Suppresses the output of HTML blocks.
-
   * `SUPPRESS_INLINE_HTML`: Suppresses the output of inline HTML elements.
-
   * `WIKILINKS`: Support `[[Wiki-style links]]` with a customizable URL rendering logic.
-
   * `STRIKETHROUGH`: Support `~~strikethroughs~~` as supported in [Pandoc] and
     [Github-flavoured-Markdown].
-
   * `ATXHEADERSPACE`: Require a space between the `#` and the header title text, as per
     [Github-flavoured-Markdown]. Frees up `#` without a space to be just plain text.
-
   * `FORCELISTITEMPARA`: Wrap a list item or definition term in `<p>` tags if it contains more
     than a simple paragraph.
-
   * `RELAXEDHRULES`: allow horizontal rules without a blank line following them.
-
   * `TASKLISTITEMS`: parses bullet lists of the form `* [ ]`, `* [x]` and `* [X]` to create
     [Github-flavoured-Markdown] task list items.
-
   * `EXTANCHORLINKS`: Generate anchor links for headers using complete contents of the header.
     * Spaces and non-alphanumerics replaced by `-`, multiple dashes trimmed to one.
     * Anchor link is added as first element inside the header with empty content: `<h1><a
       name="header"></a>header</h1>`
-
   * `EXTANCHORLINKS_WRAP`: used in conjunction with above to create an anchor that wraps header
     content: `<h1><a name="header">header</a></h1>`
-
   * `TOC`: used to enable table of contents extension `[TOC]` The TOC tag has the following
     format: `[TOC style]`. `style` consists of space separated list of options:
     * `levels=levelList` where level list is a comma separated list of levels or ranges. Default
@@ -267,16 +222,13 @@ Configuration options:
     * `reversed`: flat reversed list of headings
     * `increasing`: flat, alphabetically increasing by heading text
     * `decreasing`: flat, alphabetically decreasing by heading text
-
   * `MULTI_LINE_IMAGE_URLS`: enables parsing of image urls spanning more than one line the
     format is strict `![alt text](urladdress?` must be the last non-blank segment on a line. The
     terminating `)` or `"title")` must be the first non-indented segment on the line. Everything
     in between is sucked up as part of the URL except for blank lines.
-
   * `RELAXED_STRONG_EMPHASIS_RULES`: allow Strong/Emphasis marks to start when not preceded by
     alphanumeric for `_` and as long as not surrounded by spaces for `*` instead of only when
     preceded by spaces.
-
   * `FOOTNOTES`: Support MultiMarkdown style footnotes: `[^n] for footnote reference` and `[^n]:
     Footnote text` for footnotes. Where `n` is one or more digit, letter, `-`, `_` or `.`.
     Footnotes will be put at the bottom of the page, sequentially numbered in order of
@@ -334,9 +286,7 @@ Configuration options:
     </div>
 
   * `SUBSCRIPT`: subscript extension `~subscript~`
-
   * `SUPERSCRIPT`: superscript extension `^superscript^`
-
   * `INSERTED`: inserted or underlined extension `++inserted++`
 
 * `removeMarkdownHeaders`: Remove headers on top of markdown files if exists.

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- mvn test org.owasp:dependency-check-maven:check -->
+            <!-- mvn test org.owasp:dependency-check-maven:check
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
@@ -250,7 +250,7 @@
                 <configuration>
                     <failOnError>false</failOnError>
                 </configuration>
-            </plugin>
+            </plugin> -->
             <!-- mvn versions:display-dependency-updates -->
             <!-- mvn versions:display-plugin-updates -->
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.ruleoftech</groupId>
     <artifactId>markdown-page-generator-plugin</artifactId>
-    <version>2.4.4-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
     <name>Markdown Page Generator Maven Plugin</name>
     <description>Markdown to HTML Page Generator Maven Plugin</description>
@@ -33,8 +33,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.version>3.8.1</maven.version>
-        <flexmark.version>0.50.50</flexmark.version>
+        <maven.version>3.8.9</maven.version>
+        <flexmark.version>0.64.8</flexmark.version>
     </properties>
 
     <dependencies>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.1</version>
+            <version>3.6.4</version>
             <scope>provided</scope>
         </dependency>
 
@@ -65,6 +65,12 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.14.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-all</artifactId>
+            <version>${flexmark.version}</version>
         </dependency>
 
         <dependency>
@@ -122,7 +128,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>3.0.0-M4</version>
+                    <version>3.3.1</version>
                     <configuration>
                         <useReleaseProfile>false</useReleaseProfile>
                         <releaseProfiles>release</releaseProfiles>
@@ -136,7 +142,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>3.6.2</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>
@@ -156,7 +162,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
+                <version>1.7.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -176,7 +182,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.15.0</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>
@@ -184,11 +190,11 @@
             </plugin>
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.0.0-M4</version>
+                <version>3.3.1</version>
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.12.0</version>
                 <configuration>
                     <source>8</source>
                 </configuration>
@@ -205,7 +211,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M4</version>
+                <version>3.5.5</version>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
@@ -213,7 +219,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.14</version>
                 <executions>
                     <execution>
                         <goals>
@@ -233,7 +239,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>12.2.0</version>
+                <version>12.2.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -250,9 +256,8 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.7</version>
+                <version>2.21.0</version>
                 <configuration>
-                    <allowAnyUpdates>false</allowAnyUpdates>
                     <allowMajorUpdates>false</allowMajorUpdates>
                     <allowMinorUpdates>false</allowMinorUpdates>
                     <processDependencyManagement>false</processDependencyManagement>
@@ -269,7 +274,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.2.1</version>
+                        <version>3.4.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -282,7 +287,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.4</version>
+                        <version>3.12.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -295,7 +300,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.2.8</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,13 @@
 
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
-            <artifactId>flexmark-all</artifactId>
+            <artifactId>flexmark</artifactId>
+            <version>${flexmark.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-ext-wikilink</artifactId>
             <version>${flexmark.version}</version>
         </dependency>
 

--- a/src/main/java/com/ruleoftech/markdown/page/generator/plugin/AttributesExtension.java
+++ b/src/main/java/com/ruleoftech/markdown/page/generator/plugin/AttributesExtension.java
@@ -1,15 +1,15 @@
 package com.ruleoftech.markdown.page.generator.plugin;
 
-import com.vladsch.flexmark.util.builder.Extension;
+import com.vladsch.flexmark.util.misc.Extension;
 import com.vladsch.flexmark.html.HtmlRenderer;
-import com.vladsch.flexmark.util.html.Attributes;
+import com.vladsch.flexmark.util.html.MutableAttributes;
 import com.vladsch.flexmark.util.data.DataKey;
 import com.vladsch.flexmark.util.data.MutableDataHolder;
 
 import java.util.Map;
 
 public class AttributesExtension implements HtmlRenderer.HtmlRendererExtension {
-    final static public DataKey<Map<String, Attributes>> ATTRIBUTE_MAP = new DataKey<>("ATTRIBUTE_MAP", (Map<String, Attributes>) null);
+    final static public DataKey<Map<String, MutableAttributes>> ATTRIBUTE_MAP = new DataKey<>("ATTRIBUTE_MAP", (Map<String, MutableAttributes>) null);
 
     @Override
     public void rendererOptions(final MutableDataHolder options) {

--- a/src/main/java/com/ruleoftech/markdown/page/generator/plugin/FlexmarkAttributeProvider.java
+++ b/src/main/java/com/ruleoftech/markdown/page/generator/plugin/FlexmarkAttributeProvider.java
@@ -5,14 +5,14 @@ import com.vladsch.flexmark.html.AttributeProvider;
 import com.vladsch.flexmark.html.IndependentAttributeProviderFactory;
 import com.vladsch.flexmark.html.renderer.AttributablePart;
 import com.vladsch.flexmark.html.renderer.LinkResolverContext;
-import com.vladsch.flexmark.util.html.Attributes;
+import com.vladsch.flexmark.util.html.MutableAttributes;
 import com.vladsch.flexmark.util.data.DataHolder;
 
 import java.util.Map;
 
 public class FlexmarkAttributeProvider implements AttributeProvider {
 
-    final protected Map<String, Attributes> attributeMap;
+    final protected Map<String, MutableAttributes> attributeMap;
 
     public FlexmarkAttributeProvider(LinkResolverContext context) {
         DataHolder options = context.getOptions();
@@ -20,9 +20,9 @@ public class FlexmarkAttributeProvider implements AttributeProvider {
     }
 
     @Override
-    public void setAttributes(Node node, AttributablePart part, Attributes attributes) {
+    public void setAttributes(Node node, AttributablePart part, MutableAttributes attributes) {
         if (attributeMap != null) {
-            Attributes attributes1 = attributeMap.get(node.getClass().getSimpleName());
+            MutableAttributes attributes1 = attributeMap.get(node.getClass().getSimpleName());
             if (attributes1 != null) {
                 attributes.replaceValues(attributes1);
             }
@@ -34,7 +34,7 @@ public class FlexmarkAttributeProvider implements AttributeProvider {
         public AttributeProvider apply(LinkResolverContext context) {
             return new FlexmarkAttributeProvider(context);
         }
-        
-        
+
+
     }
 }

--- a/src/main/java/com/ruleoftech/markdown/page/generator/plugin/FlexmarkLinkResolver.java
+++ b/src/main/java/com/ruleoftech/markdown/page/generator/plugin/FlexmarkLinkResolver.java
@@ -14,13 +14,13 @@ import java.util.Set;
 public class FlexmarkLinkResolver implements LinkResolver {
     final String[] inputFileExtensions;
 
-    public FlexmarkLinkResolver(LinkResolverContext context) {
+    public FlexmarkLinkResolver(LinkResolverBasicContext context) {
         DataHolder options = context.getOptions();
         this.inputFileExtensions = options.get(PageGeneratorExtension.INPUT_FILE_EXTENSIONS).trim().split("\\s*,\\s*");
     }
 
     @Override
-    public ResolvedLink resolveLink(Node node, LinkResolverContext context, ResolvedLink link) {
+    public ResolvedLink resolveLink(Node node, LinkResolverBasicContext context, ResolvedLink link) {
         ResolvedLink result = link;
 
         for (String inputFileExtension : inputFileExtensions) {
@@ -45,14 +45,14 @@ public class FlexmarkLinkResolver implements LinkResolver {
 
     public static class Factory extends IndependentLinkResolverFactory {
         @Override
-        public Set<Class<? extends LinkResolverFactory>> getBeforeDependents() {
-            Set<Class<? extends LinkResolverFactory>> set = new HashSet<Class<? extends LinkResolverFactory>>();
+        public Set<Class<?>> getBeforeDependents() {
+            Set<Class<?>> set = new HashSet<Class<?>>();
             set.add(WikiLinkLinkResolver.Factory.class);
             return set;
         }
 
         @Override
-        public LinkResolver apply(LinkResolverContext context) {
+        public LinkResolver apply(LinkResolverBasicContext context) {
             return new FlexmarkLinkResolver(context);
         }
     }

--- a/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
+++ b/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
@@ -49,6 +49,7 @@ import com.vladsch.flexmark.profile.pegdown.PegdownOptionsAdapter;
 import com.vladsch.flexmark.util.ast.Node;
 import com.vladsch.flexmark.util.misc.Extension;
 import com.vladsch.flexmark.util.data.DataKey;
+import com.vladsch.flexmark.util.data.DataKeyBase;
 import com.vladsch.flexmark.util.data.MutableDataHolder;
 import com.vladsch.flexmark.util.data.MutableDataSet;
 import com.vladsch.flexmark.util.html.MutableAttributes;
@@ -496,7 +497,7 @@ public class MdPageGeneratorMojo extends AbstractMojo {
 
         if (getLog().isDebugEnabled()) {
             StringBuilder finalOptions = new StringBuilder("final flexmark options: ");
-            for (DataKey<?> opt : finalFlexmarkOptions.getKeys()) {
+            for (DataKeyBase<?> opt : finalFlexmarkOptions.getKeys()) {
                 finalOptions.append(opt.getName());
                 finalOptions.append(" ");
             }

--- a/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
+++ b/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
@@ -494,12 +494,14 @@ public class MdPageGeneratorMojo extends AbstractMojo {
 
         finalFlexmarkOptions.set(Parser.EXTENSIONS, extensions);
 
-        // StringBuilder finalOptions = new StringBuilder("final flexmark options: ");
-        // for (DataKey<?> opt : finalFlexmarkOptions.keySet()) {
-        //     finalOptions.append(opt.getName());
-        //     finalOptions.append(" ");
-        // }
-        // getLog().debug(finalOptions.toString());
+        if (getLog().isDebugEnabled()) {
+            StringBuilder finalOptions = new StringBuilder("final flexmark options: ");
+            for (DataKey<?> opt : finalFlexmarkOptions.getKeys()) {
+                finalOptions.append(opt.getName());
+                finalOptions.append(" ");
+            }
+            getLog().debug(finalOptions.toString());
+        }
 
         Parser parser = Parser.builder(finalFlexmarkOptions).build();
         HtmlRenderer renderer = HtmlRenderer.builder(finalFlexmarkOptions).build();

--- a/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
+++ b/src/main/java/com/ruleoftech/markdown/page/generator/plugin/MdPageGeneratorMojo.java
@@ -44,14 +44,14 @@ import org.codehaus.plexus.util.StringUtils;
 
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
-import com.vladsch.flexmark.profiles.pegdown.Extensions;
-import com.vladsch.flexmark.profiles.pegdown.PegdownOptionsAdapter;
+import com.vladsch.flexmark.profile.pegdown.Extensions;
+import com.vladsch.flexmark.profile.pegdown.PegdownOptionsAdapter;
 import com.vladsch.flexmark.util.ast.Node;
-import com.vladsch.flexmark.util.builder.Extension;
+import com.vladsch.flexmark.util.misc.Extension;
 import com.vladsch.flexmark.util.data.DataKey;
 import com.vladsch.flexmark.util.data.MutableDataHolder;
 import com.vladsch.flexmark.util.data.MutableDataSet;
-import com.vladsch.flexmark.util.html.Attributes;
+import com.vladsch.flexmark.util.html.MutableAttributes;
 
 /**
  * Creates a static html from markdown files.
@@ -192,7 +192,7 @@ public class MdPageGeneratorMojo extends AbstractMojo {
             int pegdownOptions = getPegdownExtensions(pegdownExtensions);
             MutableDataHolder flexmarkParserOptions = getFlexmarkParserOptions(this.flexmarkParserOptions);
             MutableDataHolder flexmarkRendererOptions = getFlexmarkRendererOptions(this.flexmarkRendererOptions);
-            final Map<String, Attributes> attributesMap = processAttributes(attributes);
+            final Map<String, MutableAttributes> attributesMap = processAttributes(attributes);
 
             getLog().info("Parse Markdown to HTML");
             processMarkdown(markdownDTOs, pegdownOptions, flexmarkParserOptions, flexmarkRendererOptions, attributesMap);
@@ -261,12 +261,12 @@ public class MdPageGeneratorMojo extends AbstractMojo {
      * @param attributeList list of attributes
      * @return map of Node class to attributable part and attributes
      */
-    private Map<String, Attributes> processAttributes(String[] attributeList) {
-        Map<String, Attributes> nodeAttributeMap = new HashMap<>();
+    private Map<String, MutableAttributes> processAttributes(String[] attributeList) {
+        Map<String, MutableAttributes> nodeAttributeMap = new HashMap<>();
 
         for (String attribute : attributeList) {
             String[] nodeAttributes = attribute.split("\\|");
-            Attributes attributes = new Attributes();
+            MutableAttributes attributes = new MutableAttributes();
             for (int i = 1; i < nodeAttributes.length; i++) {
                 String[] attributeNameValue = nodeAttributes[i].split("=", 2);
                 if (attributeNameValue.length > 1) {
@@ -468,7 +468,7 @@ public class MdPageGeneratorMojo extends AbstractMojo {
                                  int pegdownOptions,
                                  MutableDataHolder flexmarkParserOptions,
                                  MutableDataHolder flexmarkRendererOptions,
-                                 final Map<String, Attributes> attributesMap
+                                 final Map<String, MutableAttributes> attributesMap
     ) throws MojoExecutionException {
         getLog().debug("Process Markdown");
         getLog().debug("inputEncoding: '" + getInputEncoding() + "', outputEncoding: '" + getOutputEncoding() + "'");
@@ -494,12 +494,12 @@ public class MdPageGeneratorMojo extends AbstractMojo {
 
         finalFlexmarkOptions.set(Parser.EXTENSIONS, extensions);
 
-        StringBuilder finalOptions = new StringBuilder("final flexmark options: ");
-        for (DataKey<?> opt : finalFlexmarkOptions.keySet()) {
-            finalOptions.append(opt.getName());
-            finalOptions.append(" ");
-        }
-        getLog().debug(finalOptions.toString());
+        // StringBuilder finalOptions = new StringBuilder("final flexmark options: ");
+        // for (DataKey<?> opt : finalFlexmarkOptions.keySet()) {
+        //     finalOptions.append(opt.getName());
+        //     finalOptions.append(" ");
+        // }
+        // getLog().debug(finalOptions.toString());
 
         Parser parser = Parser.builder(finalFlexmarkOptions).build();
         HtmlRenderer renderer = HtmlRenderer.builder(finalFlexmarkOptions).build();

--- a/src/main/java/com/ruleoftech/markdown/page/generator/plugin/PageGeneratorExtension.java
+++ b/src/main/java/com/ruleoftech/markdown/page/generator/plugin/PageGeneratorExtension.java
@@ -1,6 +1,6 @@
 package com.ruleoftech.markdown.page.generator.plugin;
 
-import com.vladsch.flexmark.util.builder.Extension;
+import com.vladsch.flexmark.util.misc.Extension;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.util.data.DataKey;
 import com.vladsch.flexmark.util.data.MutableDataHolder;

--- a/src/test/java/com/ruleoftech/markdown/page/generator/plugin/FlexmarkLinkResolverTest.java
+++ b/src/test/java/com/ruleoftech/markdown/page/generator/plugin/FlexmarkLinkResolverTest.java
@@ -10,6 +10,7 @@ import com.vladsch.flexmark.html.renderer.NodeRendererContext;
 import com.vladsch.flexmark.html.renderer.RenderingPhase;
 import com.vladsch.flexmark.html.renderer.ResolvedLink;
 import com.vladsch.flexmark.util.html.Attributes;
+import com.vladsch.flexmark.util.html.MutableAttributes;
 import com.vladsch.flexmark.util.data.DataHolder;
 import com.vladsch.flexmark.util.data.MutableDataSet;
 
@@ -25,12 +26,12 @@ public class FlexmarkLinkResolverTest extends BetterAbstractMojoTestCase {
         // Given
         NodeRendererContext context = new NodeRendererContext() {
             @Override
-            public Attributes extendRenderingNodeAttributes(AttributablePart part, Attributes attributes) {
+            public MutableAttributes extendRenderingNodeAttributes(AttributablePart part, Attributes attributes) {
                 return null;
             }
-            
+
             @Override
-            public Attributes extendRenderingNodeAttributes(Node node, AttributablePart part, Attributes attributes) {
+            public MutableAttributes extendRenderingNodeAttributes(Node node, AttributablePart part, Attributes attributes) {
             	return null;
             }
 
@@ -38,12 +39,12 @@ public class FlexmarkLinkResolverTest extends BetterAbstractMojoTestCase {
             public HtmlWriter getHtmlWriter() {
                 return null;
             }
-            
+
             @Override
             public NodeRendererContext getSubContext(boolean inheritIndent) {
             	return null;
             }
-            
+
             @Override
             public NodeRendererContext getDelegatedSubContext(boolean inheritIndent) {
             	return null;


### PR DESCRIPTION
- Update Flexmark to 0.64.8 with breaking changes, see: https://github.com/vsch/flexmark-java/wiki/Version-0.60.0-Changes
- Update also other dependencies to latest versions